### PR TITLE
MON-181: Add tvOS support to ZipArchive

### DIFF
--- a/WPZipArchive.podspec
+++ b/WPZipArchive.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'WPZipArchive'
-  s.version      = '0.1.0'
+  s.version      = '0.1.1'
   s.summary      = 'Utility class for zipping and unzipping files on iOS and Mac.'
   s.description  = 'WPZipArchive is a simple utility class for zipping and unzipping files on iOS and Mac.'
   s.homepage     = 'https://github.com/WPMedia/WPZipArchive'
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.authors      = { 'Sean Soper' => 'sean.soper@gmail.com' }
   s.source       = { :git => 'https://github.com/WPMedia/WPZipArchive.git', :tag => s.version }
   s.ios.deployment_target = '4.3'
+  s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
   s.osx.deployment_target = '10.6'
   s.source_files = 'WPZipArchive/*', 'WPZipArchive/minizip/*'


### PR DESCRIPTION
[Jira](https://arcpublishing.atlassian.net/browse/MON-181)

This change is needed so that PostKit/Bundle can support tvOS

```
 -> WPZipArchive (0.1.1)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | [tvOS] xcodebuild:  note: Planning build
    - NOTE  | [tvOS] xcodebuild:  note: Constructing build description
    - WARN  | [tvOS] xcodebuild:  /Users/macbellingrath/Code/WPZipArchive/WPZipArchive/minizip/unzip.c:1173:52: warning: possible misuse of comma operator here [-Wcomma]
    - NOTE  | [tvOS] xcodebuild:  /Users/macbellingrath/Code/WPZipArchive/WPZipArchive/minizip/unzip.c:1173:9: note: cast expression to void to silence warning

WPZipArchive passed validation.
```